### PR TITLE
Implement chunked upload

### DIFF
--- a/src/app/main/files/upload/page.tsx
+++ b/src/app/main/files/upload/page.tsx
@@ -438,6 +438,7 @@ export default function UploadPage() {
       method: 'POST',
       headers,
       body: stream,
+      duplex: 'half'
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- implement `streamUploadFile` for chunked streaming upload
- remove old `XMLHttpRequest` logic and use streaming in `handleUpload`

## Testing
- `npm run lint` *(fails: Next.js lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686393dad648832a8a9f23dba025f9dc